### PR TITLE
Prefix problem filenames with "euler"

### DIFF
--- a/EulerPy/euler.py
+++ b/EulerPy/euler.py
@@ -169,8 +169,7 @@ def verify_all(num):
         sys.exit(1)
 
     for file in files:
-        # TODO use regular expression and/or BASE_NAME to find the number
-        p = Problem(int(file[5:8]))
+        p = Problem.from_filename(file)
 
         # Catch KeyboardInterrupt during verification to allow the user to
         # skip the verification of a specific problem if it takes too long
@@ -250,8 +249,8 @@ def main(option, problem):
     if problem == 0 or option in {skip, verify_all}:
         # Determine the highest problem number in the current directory
         files = problem_glob()
-        # TODO use regular expression and/or BASE_NAME to find the number
-        problem = max(int(file[5:8]) for file in files) if files else 0
+        problem = max(Problem.number_from_filename(file)
+                      for file in files) if files else 0
 
         # No Project Euler files in current directory (no glob results)
         if problem == 0:

--- a/EulerPy/euler.py
+++ b/EulerPy/euler.py
@@ -169,7 +169,8 @@ def verify_all(num):
         sys.exit(1)
 
     for file in files:
-        p = Problem(int(file[:3]))
+        # TODO use regular expression and/or BASE_NAME to find the number
+        p = Problem(int(file[5:8]))
 
         # Catch KeyboardInterrupt during verification to allow the user to
         # skip the verification of a specific problem if it takes too long
@@ -249,7 +250,8 @@ def main(option, problem):
     if problem == 0 or option in {skip, verify_all}:
         # Determine the highest problem number in the current directory
         files = problem_glob()
-        problem = max(int(file[:3]) for file in files) if files else 0
+        # TODO use regular expression and/or BASE_NAME to find the number
+        problem = max(int(file[5:8]) for file in files) if files else 0
 
         # No Project Euler files in current directory (no glob results)
         if problem == 0:

--- a/EulerPy/problem.py
+++ b/EulerPy/problem.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
 import sys
 import glob
 import json
@@ -11,16 +12,27 @@ import click
 
 BASE_NAME = 'euler{0:03d}{1}{2}'  # problem number | suffix | extension
 BASE_GLOB = 'euler[0-9][0-9][0-9]{0}{1}'
+BASE_RE = 'euler([0-9]{3})(.*)(\..*)'
 EULER_DATA = os.path.join(os.path.dirname(__file__), 'data')
 
 class Problem(object):
     def __init__(self, problem_number):
         self.num = problem_number
 
+    @staticmethod
+    def from_filename(filename):
+        number = Problem.number_from_filename(filename)
+        return Problem(number)
+
     @property
     def filename(self):
         """Returns filename padded with leading zeros"""
         return BASE_NAME.format(self.num, '', '.py')
+
+    @staticmethod
+    def number_from_filename(filename):
+        """Extract the problem number from a filename."""
+        return int(re.match(BASE_RE, filename).groups()[0])
 
     def suf_name(self, suffix, extension='.py'):
         """Similar to filename property but takes a suffix argument"""

--- a/EulerPy/problem.py
+++ b/EulerPy/problem.py
@@ -10,6 +10,7 @@ import shutil
 import click
 
 BASE_NAME = 'euler{0:03d}{1}{2}'  # problem number | suffix | extension
+BASE_GLOB = 'euler[0-9][0-9][0-9]{0}{1}'
 EULER_DATA = os.path.join(os.path.dirname(__file__), 'data')
 
 class Problem(object):

--- a/EulerPy/problem.py
+++ b/EulerPy/problem.py
@@ -9,7 +9,7 @@ import shutil
 
 import click
 
-BASE_NAME = '{0:03d}{1}{2}'  # problem number | suffix | extension
+BASE_NAME = 'euler{0:03d}{1}{2}'  # problem number | suffix | extension
 EULER_DATA = os.path.join(os.path.dirname(__file__), 'data')
 
 class Problem(object):
@@ -29,7 +29,7 @@ class Problem(object):
     @property
     def glob(self):
         """Returns a sorted glob of files belonging to a given problem"""
-        file_glob = glob.glob('{0:03d}*.*'.format(self.num))
+        file_glob = glob.glob('euler{0:03d}*.*'.format(self.num))
 
         # Sort globbed files by tuple (filename, extension)
         return sorted(file_glob, key=lambda f: os.path.splitext(f))

--- a/EulerPy/problem.py
+++ b/EulerPy/problem.py
@@ -29,7 +29,7 @@ class Problem(object):
     @property
     def glob(self):
         """Returns a sorted glob of files belonging to a given problem"""
-        file_glob = glob.glob('euler{0:03d}*.*'.format(self.num))
+        file_glob = glob.glob(BASE_NAME.format(self.num, '*', '.*'))
 
         # Sort globbed files by tuple (filename, extension)
         return sorted(file_glob, key=lambda f: os.path.splitext(f))

--- a/EulerPy/utils.py
+++ b/EulerPy/utils.py
@@ -9,10 +9,11 @@ import math
 
 import click
 
+from EulerPy.problem import BASE_GLOB
 
 def problem_glob(extension='.py'):
     """Searches through current directory for valid problem files"""
-    return glob.glob('euler[0-9][0-9][0-9]*{0}'.format(extension))
+    return glob.glob(BASE_GLOB.format('*', extension))
 
 
 def rename(old, new):

--- a/EulerPy/utils.py
+++ b/EulerPy/utils.py
@@ -12,7 +12,7 @@ import click
 
 def problem_glob(extension='.py'):
     """Searches through current directory for valid problem files"""
-    return glob.glob('[0-9][0-9][0-9]*{0}'.format(extension))
+    return glob.glob('euler[0-9][0-9][0-9]*{0}'.format(extension))
 
 
 def rename(old, new):

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ are being stored.
 
 
 At this point, you'll probably want to run the ``euler`` command, which will
-prompt to create ``001.py``, a file containing the text to Project Euler problem
+prompt to create ``euler001.py``, a file containing the text to Project Euler problem
 #1 as its docstring.
 
 .. code-block:: bash
@@ -56,9 +56,9 @@ prompt to create ``001.py``, a file containing the text to Project Euler problem
     $ euler
     No Project Euler files found in the current directory.
     Generate file for problem 1? [Y/n]: Y
-    Successfully created "001.py".
+    Successfully created "euler001.py".
 
-    $ cat 001.py
+    $ cat euler001.py
     """
     Project Euler Problem 1
     =======================
@@ -80,13 +80,13 @@ time elapsed during the solution-checking process will also be printed.
 .. code-block:: bash
 
     $ euler
-    Checking "001.py" against solution: [no output] # (output in red)
+    Checking "euler001.py" against solution: [no output] # (output in red)
 
-    $ echo print 42 >> 001.py
+    $ echo print 42 >> euler001.py
     $ euler
-    Checking "001.py" against solution: 42 # (output in green)
+    Checking "euler001.py" against solution: 42 # (output in green)
     Generate file for problem 2? [Y/n]: Y
-    Successfully created "002.py".
+    Successfully created "euler002.py".
 
 
 EulerPy also has a few command line options that act as different commands
@@ -123,8 +123,8 @@ the user).
 
     $ euler --generate
     Generate file for problem 2? [Y/n]: Y
-    "002.py" already exists. Overwrite? [y/N]:
-    Successfully created "002.py".
+    "euler002.py" already exists. Overwrite? [y/N]:
+    Successfully created "euler002.py".
 
     $ euler --generate 5
     Generate file for problem 5? [Y/n]: n
@@ -135,8 +135,8 @@ the user).
 
 .. code-block:: bash
 
-    $ cat 005.py
-    cat: 005.py: No such file or directory
+    $ cat euler005.py
+    cat: euler005.py: No such file or directory
 
     $ euler 5
     Generate file for problem 5? [Y/n]: n
@@ -149,7 +149,7 @@ resource files to a ``resources`` subdirectory.
 
     $ euler 22
     Generate file for problem 22? [Y/n]: Y
-    Successfully created "022.py".
+    Successfully created "euler022.py".
     Copied "names.txt" to project-euler/resources.
 
 
@@ -188,8 +188,8 @@ file.
     $ euler --skip
     Current problem is problem 2.
     Generate file for problem 3? [y/N]: Y
-    Successfully created "003.py".
-    Renamed "002.py" to "002-skipped.py".
+    Successfully created "euler003.py".
+    Renamed "euler002.py" to "euler002-skipped.py".
 
 
 ``--verify / -v``
@@ -202,10 +202,10 @@ check the current problem.
 .. code-block:: bash
 
     $ euler --verify
-    Checking "003.py" against solution: [no output] # (output in red)
+    Checking "euler003.py" against solution: [no output] # (output in red)
 
     $ euler --verify 1
-    Checking "001.py" against solution: <redacted> # (output in green)
+    Checking "euler001.py" against solution: <redacted> # (output in green)
 
 As of EulerPy v1.1, verifying a skipped problem file will remove the "skipped"
 suffix from its filename.
@@ -213,15 +213,15 @@ suffix from its filename.
 .. code-block:: bash
 
     $ euler --verify 1
-    Checking "001-skipped.py" against solution: <redcated>
-    Renamed "001-skipped.py" to "001.py".
+    Checking "euler001-skipped.py" against solution: <redcated>
+    Renamed "euler001-skipped.py" to "euler001.py".
 
 ``euler <problem>`` is equivalent to ``euler --verify <problem>`` if the file
 **does** exist.
 
 .. code-block:: bash
 
-    $ cat 001.py
+    $ cat euler001.py
     """
     Project Euler Problem 1
     =======================
@@ -234,7 +234,7 @@ suffix from its filename.
 
 
     $ euler 1
-    Checking "001.py" against solution: <redacted>
+    Checking "euler001.py" against solution: <redacted>
 
 
 ``--verify-all``
@@ -251,9 +251,9 @@ taking too long to compute.
 .. code-block:: bash
 
     $ euler --verify-all
-    Checking "001.py" against solution: <redacted>
+    Checking "euler001.py" against solution: <redacted>
 
-    Checking "002.py" against solution: [no output]
+    Checking "euler002.py" against solution: [no output]
 
     ---------------------------------------------------------------
     C = correct, I = incorrect, E = error, S = skipped, . = missing

--- a/tests/test_euler.py
+++ b/tests/test_euler.py
@@ -51,25 +51,25 @@ class EulerPyNoOption(EulerPyTest):
     def test_empty_directory_install_neutral(self):
         result = EulerRun(input='\n')
         self.assertEqual(result.exit_code, 0)
-        self.assertTrue(os.path.isfile('001.py'))
+        self.assertTrue(os.path.isfile('euler001.py'))
 
     def test_empty_directory_negative(self):
         result = EulerRun(input='N\n')
         self.assertEqual(result.exit_code, 1)
-        self.assertFalse(os.path.isfile('001.py'))
+        self.assertFalse(os.path.isfile('euler001.py'))
 
     # No option or problem number
     def test_no_arguments_first_correct(self):
         generateFile(1, correct=True)
         result = EulerRun(input='\n')
         self.assertEqual(result.exit_code, 0)
-        self.assertTrue(os.path.isfile('002.py'))
+        self.assertTrue(os.path.isfile('euler002.py'))
 
     def test_no_arguments_first_incorrect(self):
         generateFile(1)
         result = EulerRun(input='\n')
         self.assertEqual(result.exit_code, 1)
-        self.assertFalse(os.path.isfile('002.py'))
+        self.assertFalse(os.path.isfile('euler002.py'))
 
     # Ambiguous case; infer option from file existence check
     def test_ambiguous_option_generate(self):
@@ -109,17 +109,17 @@ class EulerPyGenerate(EulerPyTest):
     def test_generate_neutral(self):
         result = EulerRun('-g', input='\n')
         self.assertEqual(result.exit_code, 0)
-        self.assertTrue(os.path.isfile('001.py'))
+        self.assertTrue(os.path.isfile('euler001.py'))
 
     def test_generate_negative(self):
         result = EulerRun('-g', input='N\n')
         self.assertEqual(result.exit_code, 1)
-        self.assertFalse(os.path.isfile('001.py'))
+        self.assertFalse(os.path.isfile('euler001.py'))
 
     def test_generate_specific(self):
         result = EulerRun('-g', '5', input='\n')
         self.assertEqual(result.exit_code, 0)
-        self.assertTrue(os.path.isfile('005.py'))
+        self.assertTrue(os.path.isfile('euler005.py'))
 
     def test_generate_overwrite_positive(self):
         generateFile(1)
@@ -127,7 +127,7 @@ class EulerPyGenerate(EulerPyTest):
         result = EulerRun('-g', '1', input='\nY\n')
         self.assertEqual(result.exit_code, 0)
 
-        with open('001.py') as file:
+        with open('euler001.py') as file:
             self.assertNotEqual(file.read(), '')
 
     def test_generate_overwrite_neutral(self):
@@ -136,21 +136,21 @@ class EulerPyGenerate(EulerPyTest):
         result = EulerRun('-g', '1', input='\n\n')
         self.assertEqual(result.exit_code, 1)
 
-        with open('001.py') as file:
+        with open('euler001.py') as file:
             self.assertEqual(file.read(), '')
 
     def test_generate_overwrite_skipped(self):
-        generateFile(1, '001-skipped.py')
+        generateFile(1, 'euler001-skipped.py')
 
         result = EulerRun('-g', '1', input='\nY\n')
         self.assertEqual(result.exit_code, 0)
-        self.assertTrue(os.path.isfile('001-skipped.py'))
-        self.assertFalse(os.path.isfile('001.py'))
+        self.assertTrue(os.path.isfile('euler001-skipped.py'))
+        self.assertFalse(os.path.isfile('euler001.py'))
 
     def test_generate_copy_resources(self):
         result = EulerRun('-g', '22', input='\n')
         self.assertEqual(result.exit_code, 0)
-        self.assertTrue(os.path.isfile('022.py'))
+        self.assertTrue(os.path.isfile('euler022.py'))
 
         resource = os.path.join('resources', 'names.txt')
         self.assertTrue(os.path.isfile(resource))
@@ -185,15 +185,15 @@ class EulerPySkip(EulerPyTest):
 
         result = EulerRun('-s', input='\n')
         self.assertEqual(result.exit_code, 1)
-        self.assertTrue(os.path.isfile('001.py'))
+        self.assertTrue(os.path.isfile('euler001.py'))
 
     def test_skip_positive(self):
         generateFile(1)
 
         result = EulerRun('-s', input='Y\n')
         self.assertEqual(result.exit_code, 0)
-        self.assertFalse(os.path.isfile('001.py'))
-        self.assertTrue(os.path.isfile('001-skipped.py'))
+        self.assertFalse(os.path.isfile('euler001.py'))
+        self.assertTrue(os.path.isfile('euler001-skipped.py'))
 
 
 class EulerPyVerify(EulerPyTest):
@@ -202,30 +202,30 @@ class EulerPyVerify(EulerPyTest):
 
         result = EulerRun('-v')
         self.assertEqual(result.exit_code, 1)
-        self.assertIn('Checking "001.py"', result.output)
+        self.assertIn('Checking "euler001.py"', result.output)
 
     def test_verify_specific(self):
         generateFile(5)
 
         result = EulerRun('-v', '5')
         self.assertEqual(result.exit_code, 1)
-        self.assertIn('Checking "005.py"', result.output)
+        self.assertIn('Checking "euler005.py"', result.output)
 
     def test_verify_glob(self):
-        generateFile(1, '001-skipped.py')
+        generateFile(1, 'euler001-skipped.py')
 
         result = EulerRun('-v', '1')
         self.assertEqual(result.exit_code, 1)
-        self.assertIn('Checking "001-skipped.py"', result.output)
+        self.assertIn('Checking "euler001-skipped.py"', result.output)
 
     def test_verify_sorted_glob(self):
-        generateFile(1, '001.py')
-        generateFile(1, '001-skipped.py')
+        generateFile(1, 'euler001.py')
+        generateFile(1, 'euler001-skipped.py')
 
         result = EulerRun('-v', '1')
         self.assertEqual(result.exit_code, 1)
-        self.assertIn('Checking "001.py"', result.output)
-        self.assertNotIn('Checking "001-skipped.py"', result.output)
+        self.assertIn('Checking "euler001.py"', result.output)
+        self.assertNotIn('Checking "euler001-skipped.py"', result.output)
 
     def test_verify_correct(self):
         generateFile(1, correct=True)
@@ -247,27 +247,27 @@ class EulerPyVerify(EulerPyTest):
         generateFile(1, content='import sys; sys.exit(1)')
 
         result = EulerRun('-v', '1')
-        self.assertIn('Error calling "001.py"', result.output)
+        self.assertIn('Error calling "euler001.py"', result.output)
         self.assertEqual(result.exit_code, 1)
 
 
 class EulerPyVerifyAll(EulerPyTest):
     def test_verify_all(self):
         generateFile(1, correct=True)
-        generateFile(2, '002-skipped.py', correct=True)
+        generateFile(2, 'euler002-skipped.py', correct=True)
         generateFile(4)
         generateFile(5, content='import sys; sys.exit(1)')
 
         result = EulerRun('--verify-all')
         self.assertIn('Problems 001-020: C C . I E', result.output)
 
-        # "002-skipped.py" should have been renamed to "002.py"
-        self.assertTrue(os.path.isfile('002.py'))
-        self.assertFalse(os.path.isfile('002-skipped.py'))
+        # "euler002-skipped.py" should have been renamed to "euler002.py"
+        self.assertTrue(os.path.isfile('euler002.py'))
+        self.assertFalse(os.path.isfile('euler002-skipped.py'))
 
-        # "004.py" should have been renamed to "004-skipped.py"
-        self.assertFalse(os.path.isfile('004.py'))
-        self.assertTrue(os.path.isfile('004-skipped.py'))
+        # "euler004.py" should have been renamed to "euler004-skipped.py"
+        self.assertFalse(os.path.isfile('euler004.py'))
+        self.assertTrue(os.path.isfile('euler004-skipped.py'))
 
     def test_verify_all_no_files(self):
         result = EulerRun('--verify-all')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,9 +52,9 @@ class EulerPyUtils(unittest.TestCase):
 
     def test_filename_format(self):
         """Check that filenames are being formatted correctly"""
-        self.assertEqual(Problem(1).filename, "001.py")
-        self.assertEqual(Problem(10).filename, "010.py")
-        self.assertEqual(Problem(100).filename, "100.py")
+        self.assertEqual(Problem(1).filename, "euler001.py")
+        self.assertEqual(Problem(10).filename, "euler010.py")
+        self.assertEqual(Problem(100).filename, "euler100.py")
 
     def test_time_format(self):
         self.assertEqual(human_time(100000), '1d 3h 46m 40s')


### PR DESCRIPTION
Hi, I've made some changes to EulerPy so that the problem files are called "euler123.py" etc. instead of "123.py". The reason is that "123" etc. are illegal module names which means that code from existing solutions cannot be easily imported for re-use, profiling, or similar purposes.

I also made it so that the filename base pattern is specified in a single place in the codebase (it was spread in about three locations that I had to find first).

All tests pass when run like this:

```
EulerPy$ python -m unittest discover tests/
.........................................
----------------------------------------------------------------------
Ran 41 tests in 1.063s

OK
```